### PR TITLE
Update paper.bib

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -47,6 +47,7 @@ year = {2017}
 
 @article{Baio:2013,
 	author = {{Baio}, G.},
+	doi = {10.1002/sim.6074},
 	title = {{Bayesian models for cost-effectiveness analysis in the presence of structural zero costs}},
 	journal = {Statistics in Medicine},
 	year = {2013},


### PR DESCRIPTION
add doi for Baio (2013) - check this is the correct doi and date please. The entry [here](https://pubmed.ncbi.nlm.nih.gov/24343868/) indicates a 2014 publication data. If 2014 is correct, can you update paper.bib please?